### PR TITLE
Performance optimization

### DIFF
--- a/converter/build.gradle
+++ b/converter/build.gradle
@@ -1,12 +1,15 @@
 buildscript {
     repositories {
         mavenCentral()
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
     }
     dependencies {
-        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3"
+        classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3'
+        classpath 'gradle.plugin.me.champeau.gradle:jmh-gradle-plugin:0.3.0'
     }
 }
-
 
 plugins {
     id 'java'
@@ -14,14 +17,36 @@ plugins {
     id 'maven'
     id 'jacoco'
     id 'com.bmuschko.nexus' version '2.3.1'
+    id 'me.champeau.gradle.jmh' version '0.3.0'
 }
 
 apply plugin: 'io.codearte.nexus-staging'
+apply plugin: 'idea'
+
+configurations {
+    jmh
+}
+
+jmh {
+    include = 'tech\\.allegro\\.schema\\.json2avro\\.converter\\..*'
+    humanOutputFile = null
+    jmhVersion = '1.12'
+    iterations = 2
+    timeOnIteration = '10s'
+    fork = 1
+    warmupIterations = 1
+    warmup = '10s'
+    failOnError = true
+    threads = 1
+}
 
 dependencies {
     compile group: 'org.apache.avro', name: 'avro', version: '1.7.7'
 
     testCompile group: 'org.spockframework', name: 'spock-core', version: versions.spock
+
+    jmh 'org.openjdk.jmh:jmh-core:1.12'
+    jmh 'org.openjdk.jmh:jmh-generator-annprocess:1.12'
 }
 
 modifyPom {
@@ -59,3 +84,14 @@ nexusStaging {
     numberOfRetries = 15
     delayBetweenRetriesInMillis = 5000
 }
+
+idea {
+    module {
+        scopes.PROVIDED.plus += [ configurations.jmh ]
+    }
+}
+
+// Workaround for duplicated `BenchmarkList` and `CompilerHints` files from META-INF directory in jmh jar.
+// Those duplications can prevent from running benchmark tests.
+// More info https://github.com/melix/jmh-gradle-plugin/issues/6
+tasks.getByName('jmhJar').doFirst() {duplicatesStrategy(DuplicatesStrategy.EXCLUDE)}

--- a/converter/src/jmh/java/tech/allegro/schema/json2avro/converter/JsonAvroConverterBenchmark.java
+++ b/converter/src/jmh/java/tech/allegro/schema/json2avro/converter/JsonAvroConverterBenchmark.java
@@ -1,0 +1,87 @@
+package tech.allegro.schema.json2avro.converter;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+public class JsonAvroConverterBenchmark {
+
+    private JsonAvroConverter converter = new JsonAvroConverter();
+    private byte[] messageWithNullField;
+    private byte[] completeMessage;
+    private Schema schema;
+
+    @Setup
+    public void setup() {
+        converter = new JsonAvroConverter();
+        schema = new Schema.Parser().parse(
+                        "{" +
+                        "    \"type\" : \"record\"," +
+                        "    \"name\" : \"Acme\"," +
+                        "    \"fields\" : [" +
+                        "        { \"name\" : \"username\", \"type\" : \"string\" }," +
+                        "        { \"name\" : \"age\", \"type\" : [\"null\", \"int\"], \"default\": null }]" +
+                        "}");
+
+        messageWithNullField = "{ \"username\": \"mike\" }".getBytes();
+        completeMessage = "{ \"username\": \"mike\", \"age\": 30}".getBytes();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public GenericData.Record conversionLatencyForMessageWithNotProvidedOptionalField() {
+        return converter.convertToGenericDataRecord(messageWithNullField, schema);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public GenericData.Record conversionThroughputForMessageWithNotProvidedOptionalField() {
+        return converter.convertToGenericDataRecord(messageWithNullField, schema);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public GenericData.Record conversionLatencyForCompleteMessage() {
+        return converter.convertToGenericDataRecord(completeMessage, schema);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public GenericData.Record conversionThroughputForCompleteMessage() {
+        return converter.convertToGenericDataRecord(completeMessage, schema);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(".*" + JsonAvroConverterBenchmark.class.getSimpleName() + ".*")
+                .warmupIterations(2)
+                .measurementIterations(2)
+                .measurementTime(TimeValue.seconds(20))
+                .warmupTime(TimeValue.seconds(5))
+                .forks(1)
+                .threads(1)
+                .syncIterations(true)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+}

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/AvroTypeExceptions.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/AvroTypeExceptions.java
@@ -1,0 +1,47 @@
+package tech.allegro.schema.json2avro.converter;
+
+import org.apache.avro.AvroTypeException;
+
+import java.util.Deque;
+import java.util.stream.StreamSupport;
+
+import static java.util.Spliterator.ORDERED;
+import static java.util.Spliterators.spliteratorUnknownSize;
+import static java.util.stream.Collectors.joining;
+
+class AvroTypeExceptions {
+    static AvroTypeException enumException(Deque<String> fieldPath, String expectedSymbols) {
+        return new AvroTypeException(new StringBuilder()
+                .append("Field ")
+                .append(path(fieldPath))
+                .append(" is expected to be of enum type and be one of ")
+                .append(expectedSymbols)
+                .toString());
+    }
+
+    static AvroTypeException unionException(String fieldName, String expectedTypes, Deque<String> offendingPath) {
+        return new AvroTypeException(new StringBuilder()
+                .append("Could not evaluate union, field")
+                .append(fieldName)
+                .append("is expected to be one of these: ")
+                .append(expectedTypes)
+                .append("If this is a complex type, check if offending field: ")
+                .append(path(offendingPath))
+                .append(" adheres to schema.")
+                .toString());
+    }
+
+    static AvroTypeException typeException(Deque<String> fieldPath, String expectedType) {
+        return new AvroTypeException(new StringBuilder()
+            .append("Field ")
+            .append(path(fieldPath))
+            .append(" is expected to be type: ")
+            .append(expectedType)
+            .toString());
+    }
+
+    private static String path(Deque<String> path) {
+        return StreamSupport.stream(spliteratorUnknownSize(path.descendingIterator(), ORDERED), false)
+                .map(Object::toString).collect(joining("."));
+    }
+}


### PR DESCRIPTION
This PR speeds up conversion from json to avro through elimination of:
* exceptions from normal flow 
* usage of String.format()

# Before optimization
```
Benchmark                                                                                Mode     Cnt        Score    Error  Units
JsonAvroConverterBenchmark.conversionThroughputForCompleteMessage                       thrpt       2   269449.055           ops/s
JsonAvroConverterBenchmark.conversionThroughputForMessageWithNotProvidedOptionalField   thrpt       2  2448377.702           ops/s
JsonAvroConverterBenchmark.conversionLatencyForCompleteMessage                         sample  362647     3534.198 ± 68.884  ns/op
JsonAvroConverterBenchmark.conversionLatencyForMessageWithNotProvidedOptionalField     sample  381981      461.864 ± 14.318  ns/op
```

# After optimization
```
Benchmark                                                                                Mode     Cnt        Score    Error  Units
JsonAvroConverterBenchmark.conversionThroughputForCompleteMessage                       thrpt       2  1895774.508           ops/s
JsonAvroConverterBenchmark.conversionThroughputForMessageWithNotProvidedOptionalField   thrpt       2  2397447.209           ops/s
JsonAvroConverterBenchmark.conversionLatencyForCompleteMessage                         sample  287009      591.431 ±  7.370  ns/op
JsonAvroConverterBenchmark.conversionLatencyForMessageWithNotProvidedOptionalField     sample  367727      480.230 ± 15.620  ns/op
```

# Root causes and solutions
```
Benchmark                                                       Mode     Cnt     Score    Error  Units
LanguageBenchmark.benchExceptionThrow                          sample  246564  1324.748 ± 21.692  ns/op
LanguageBenchmark.benchObjectReturn                            sample  322717    50.053 ±  0.622  ns/op
LanguageBenchmark.benchStringFormat                            sample  296719  1112.386 ± 24.829  ns/op
LanguageBenchmark.benchStringsConcatenationViaBuilder          sample  366216    69.523 ±  4.435  ns/op
```