### PR TITLE
Add support for Avro bytes fields

### DIFF
--- a/converter/src/main/java/org/apache/avro/io/NoWrappingJsonEncoder.java
+++ b/converter/src/main/java/org/apache/avro/io/NoWrappingJsonEncoder.java
@@ -1,12 +1,11 @@
 package org.apache.avro.io;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import org.apache.avro.Schema;
 import org.apache.avro.io.parsing.Symbol;
 import org.codehaus.jackson.JsonGenerator;
+
+import java.io.IOException;
+import java.io.OutputStream;
 
 public class NoWrappingJsonEncoder extends JsonEncoder {
     public NoWrappingJsonEncoder(Schema sc, OutputStream out) throws IOException {
@@ -19,15 +18,6 @@ public class NoWrappingJsonEncoder extends JsonEncoder {
 
     public NoWrappingJsonEncoder(Schema sc, JsonGenerator out) throws IOException {
         super(sc, out);
-    }
-
-    @Override
-    public void writeBytes(byte[] bytes, int start, int len) throws IOException {
-        byte[] slice = new byte[len];
-        System.arraycopy(bytes, start, slice, 0, len);
-
-        byte[] encoded = Base64.getEncoder().encodeToString(slice).getBytes(StandardCharsets.UTF_8);
-        super.writeBytes(encoded, 0, encoded.length);
     }
 
     @Override

--- a/converter/src/main/java/org/apache/avro/io/NoWrappingJsonEncoder.java
+++ b/converter/src/main/java/org/apache/avro/io/NoWrappingJsonEncoder.java
@@ -1,11 +1,12 @@
 package org.apache.avro.io;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import org.apache.avro.Schema;
 import org.apache.avro.io.parsing.Symbol;
 import org.codehaus.jackson.JsonGenerator;
-
-import java.io.IOException;
-import java.io.OutputStream;
 
 public class NoWrappingJsonEncoder extends JsonEncoder {
     public NoWrappingJsonEncoder(Schema sc, OutputStream out) throws IOException {
@@ -18,6 +19,15 @@ public class NoWrappingJsonEncoder extends JsonEncoder {
 
     public NoWrappingJsonEncoder(Schema sc, JsonGenerator out) throws IOException {
         super(sc, out);
+    }
+
+    @Override
+    public void writeBytes(byte[] bytes, int start, int len) throws IOException {
+        byte[] slice = new byte[len];
+        System.arraycopy(bytes, start, slice, 0, len);
+
+        byte[] encoded = Base64.getEncoder().encodeToString(slice).getBytes(StandardCharsets.UTF_8);
+        super.writeBytes(encoded, 0, encoded.length);
     }
 
     @Override

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonGenericRecordReader.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonGenericRecordReader.java
@@ -1,7 +1,7 @@
 package tech.allegro.schema.json2avro.converter;
 
 import java.nio.ByteBuffer;
-import java.util.Base64;
+import java.nio.charset.StandardCharsets;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
@@ -117,7 +117,7 @@ public class JsonGenericRecordReader {
                 result = onValidType(value, String.class, path, silently, string -> string);
                 break;
             case BYTES:
-                result = onValidType(value, String.class, path, silently, string -> decodeBase64(string));
+                result = onValidType(value, String.class, path, silently, string -> bytesForString(string));
                 break;
             case NULL:
                 result = value == null ? value : INCOMPATIBLE;
@@ -171,8 +171,8 @@ public class JsonGenericRecordReader {
         throw enumException(path, symbols.stream().map(String::valueOf).collect(joining(", ")));
     }
 
-    private ByteBuffer decodeBase64(String encoded) {
-        return ByteBuffer.wrap(Base64.getDecoder().decode(encoded));
+    private ByteBuffer bytesForString(String string) {
+        return ByteBuffer.wrap(string.getBytes(StandardCharsets.UTF_8));
     }
 
     @SuppressWarnings("unchecked")

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonGenericRecordReader.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonGenericRecordReader.java
@@ -1,5 +1,7 @@
 package tech.allegro.schema.json2avro.converter;
 
+import java.nio.ByteBuffer;
+import java.util.Base64;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
@@ -114,6 +116,9 @@ public class JsonGenericRecordReader {
             case STRING:
                 result = onValidType(value, String.class, path, silently, string -> string);
                 break;
+            case BYTES:
+                result = onValidType(value, String.class, path, silently, string -> decodeBase64(string));
+                break;
             case NULL:
                 result = value == null ? value : INCOMPATIBLE;
                 break;
@@ -164,6 +169,10 @@ public class JsonGenericRecordReader {
             return new GenericData.EnumSymbol(schema, value);
         }
         throw enumException(path, symbols.stream().map(String::valueOf).collect(joining(", ")));
+    }
+
+    private ByteBuffer decodeBase64(String encoded) {
+        return ByteBuffer.wrap(Base64.getDecoder().decode(encoded));
     }
 
     @SuppressWarnings("unchecked")

--- a/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/JsonAvroConverterSpec.groovy
+++ b/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/JsonAvroConverterSpec.groovy
@@ -68,6 +68,35 @@ class JsonAvroConverterSpec extends Specification {
         toMap(json) == toMap(converter.convertToJson(avro, schema))
     }
 
+
+    def 'should convert bytes generic record'() {
+        given:
+        def schema = '''
+            {
+              "type" : "record",
+              "name" : "testSchema",
+              "fields" : [
+                  {
+                    "name" : "field_bytes",
+                    "type" : "bytes"
+                  }
+              ]
+            }
+        '''
+
+        def json = '''
+        {
+            "field_bytes": "aGVsbG8gd29ybGQ="
+        }
+        '''
+
+        when:
+        byte[] avro = converter.convertToAvro(json.bytes, schema)
+
+        then:
+        toMap(json) == toMap(converter.convertToJson(avro, schema))
+    }
+
     def "should throw exception when parsing record with mismatched primitives"() {
         given:
         def schema = '''

--- a/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/JsonAvroConverterSpec.groovy
+++ b/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/JsonAvroConverterSpec.groovy
@@ -86,7 +86,7 @@ class JsonAvroConverterSpec extends Specification {
 
         def json = '''
         {
-            "field_bytes": "aGVsbG8gd29ybGQ="
+            "field_bytes": "\\u0001\\u0002\\u0003"
         }
         '''
 


### PR DESCRIPTION
Fixes #27 

Adds support in `JsonGenericRecordReader` for decoding `bytes` fields from GenericRecord.

[According to the spec](https://avro.apache.org/docs/1.8.2/spec.html#schema_record), the JSON format encodes `bytes` fields as strings using unicode codepoints 0-255.

Alternatively, my first commit in this PR uses base64 encoding for the string representation. I'm agnostic to the choice, and in the application I'm writing use of base64 might actually be a bit easier to work with, but figured for the PR I'd try and adhere to the spec.
