### PR TITLE
allow serialization of generated enums

### DIFF
--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonAvroConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonAvroConverter.java
@@ -7,11 +7,13 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.NoWrappingJsonEncoder;
 import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.avro.specific.SpecificRecordBase;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -91,7 +93,10 @@ public class JsonAvroConverter {
         try {
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             NoWrappingJsonEncoder jsonEncoder = new NoWrappingJsonEncoder(record.getSchema(), outputStream);
-            new GenericDatumWriter<GenericRecord>(record.getSchema()).write(record, jsonEncoder);
+            DatumWriter<GenericRecord> writer = record instanceof SpecificRecord ?
+                new SpecificDatumWriter<>(record.getSchema()) :
+                new GenericDatumWriter<>(record.getSchema());
+            writer.write(record, jsonEncoder);
             jsonEncoder.flush();
             return outputStream.toByteArray();
         } catch (IOException e) {

--- a/converter/src/test/avro/test.avsc
+++ b/converter/src/test/avro/test.avsc
@@ -2,6 +2,7 @@
  "type": "record",
  "name": "SpecificRecordConvertTest",
  "fields": [
-     {"name": "test", "type": "string"}
+     {"name": "test", "type": "string"},
+     {"name": "enumTest", "type": { "type": "enum", "name": "status", "symbols": ["s1", "s2"]}}
  ]
 }

--- a/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/JsonAvroConverterSpec.groovy
+++ b/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/JsonAvroConverterSpec.groovy
@@ -896,7 +896,8 @@ class JsonAvroConverterSpec extends Specification {
         given:
         def json = '''
         {
-            "test": "test"
+            "test": "test",
+            "enumTest": "s1"
         }
         '''
         def clazz = SpecificRecordConvertTest.class
@@ -904,10 +905,24 @@ class JsonAvroConverterSpec extends Specification {
 
         when:
         SpecificRecordConvertTest result = converter.convertToSpecificRecord(json.bytes, clazz, schema)
-
+        converter.convertToJson(result)
         then:
         result != null && result instanceof SpecificRecordConvertTest && result.getTest() == "test"
     }
+
+    def 'should convert specific record and back to json'() {
+        given:
+        def json = '''{"test":"test","enumTest":"s1"}'''
+        def clazz = SpecificRecordConvertTest.class
+        def schema = SpecificRecordConvertTest.getClassSchema()
+
+        when:
+        SpecificRecordConvertTest record = converter.convertToSpecificRecord(json.bytes, clazz, schema)
+        def result = converter.convertToJson(record)
+        then:
+        result != null && new String(result) == json
+    }
+
 
     def toMap(String json) {
         slurper.parseText(json)

--- a/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/JsonAvroConverterSpec.groovy
+++ b/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/JsonAvroConverterSpec.groovy
@@ -905,7 +905,6 @@ class JsonAvroConverterSpec extends Specification {
 
         when:
         SpecificRecordConvertTest result = converter.convertToSpecificRecord(json.bytes, clazz, schema)
-        converter.convertToJson(result)
         then:
         result != null && result instanceof SpecificRecordConvertTest && result.getTest() == "test"
     }


### PR DESCRIPTION
The `GenericDatumWriter` does not work for enums in generated classes. The test fails without the patch.