### PR TITLE
Make enum parsing fall back to default value in schema

### DIFF
--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonGenericRecordReader.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonGenericRecordReader.java
@@ -168,6 +168,9 @@ public class JsonGenericRecordReader {
         if (symbols.contains(value)) {
             return new GenericData.EnumSymbol(schema, value);
         }
+        else if (schema.getEnumDefault() != null) {
+            return new GenericData.EnumSymbol(schema, schema.getEnumDefault());
+        }
         throw enumException(path, symbols.stream().map(String::valueOf).collect(joining(", ")));
     }
 

--- a/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/JsonAvroConverterSpec.groovy
+++ b/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/JsonAvroConverterSpec.groovy
@@ -848,6 +848,45 @@ class JsonAvroConverterSpec extends Specification {
         exception.cause.message  ==~ /.*enum type and be one of A, B, C.*/
     }
 
+    def 'should fallback to enum default when passing an invalid enum type'() {
+        given:
+        def schema = '''
+            {
+              "name": "testSchema",
+              "type": "record",
+              "fields": [
+                  {
+                    "name" : "field_enum",
+                    "type" : {
+                        "name" : "MyEnums",
+                        "type" : "enum",
+                        "symbols" : [ "A", "B", "C" ],
+                        "default" : "B"
+                    }
+                  }
+              ]
+            }
+        '''
+
+        def json = '''
+        {
+            "field_enum": "D"
+        }
+        '''
+
+        def jsonAfterParse = '''
+        {
+            "field_enum": "B"
+        }
+        '''
+
+        when:
+        def result = converter.convertToJson(converter.convertToAvro(json.bytes, schema), schema)
+
+        then:
+        toMap(jsonAfterParse) == toMap(result)
+    }
+
     def 'should accept null when value can be of any nullable array/map type'() {
         given:
         def schema = '''


### PR DESCRIPTION
This feature sort of tracks the behaviour of Avro itself.
Interesting discussion of Enum schema evolution here:
https://issues.apache.org/jira/browse/AVRO-1340