### PR TITLE
Remove unnecessary dependency on SpecificRecordBase

### DIFF
--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonAvroConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonAvroConverter.java
@@ -15,7 +15,6 @@ import org.apache.avro.io.NoWrappingJsonEncoder;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.specific.SpecificRecord;
-import org.apache.avro.specific.SpecificRecordBase;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.ByteArrayInputStream;
@@ -58,7 +57,7 @@ public class JsonAvroConverter {
         return recordReader.read(data, schema);
     }
 
-    public <T extends SpecificRecordBase & SpecificRecord> T convertToSpecificRecord(byte[] jsonData, Class<T> clazz, Schema schema) {
+    public <T extends SpecificRecord> T convertToSpecificRecord(byte[] jsonData, Class<T> clazz, Schema schema) {
         byte[] avroBinaryData = this.convertToAvro(jsonData, schema);
         SpecificDatumReader<T> reader = new SpecificDatumReader<T>(clazz);
         ByteArrayInputStream inStream = new ByteArrayInputStream(avroBinaryData);
@@ -71,7 +70,7 @@ public class JsonAvroConverter {
         }
     }
 
-    public <T extends SpecificRecordBase & SpecificRecord> T convertToSpecificRecord(byte[] data, Class<T> clazz, String schema) {
+    public <T extends SpecificRecord> T convertToSpecificRecord(byte[] data, Class<T> clazz, String schema) {
         return convertToSpecificRecord(data, clazz, new Schema.Parser().parse(schema));
     }
 


### PR DESCRIPTION
By having it return a type which implements SpecificRecord only gives us more flexibility in usage.