### PR TITLE
Make Converter classes Serializable

### DIFF
--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonAvroConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonAvroConverter.java
@@ -21,8 +21,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 
-public class JsonAvroConverter {
+public class JsonAvroConverter implements Serializable {
     private JsonGenericRecordReader recordReader;
 
     public JsonAvroConverter() {

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonGenericRecordReader.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonGenericRecordReader.java
@@ -1,5 +1,6 @@
 package tech.allegro.schema.json2avro.converter;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import org.apache.avro.AvroRuntimeException;
@@ -24,7 +25,7 @@ import static tech.allegro.schema.json2avro.converter.AvroTypeExceptions.enumExc
 import static tech.allegro.schema.json2avro.converter.AvroTypeExceptions.typeException;
 import static tech.allegro.schema.json2avro.converter.AvroTypeExceptions.unionException;
 
-public class JsonGenericRecordReader {
+public class JsonGenericRecordReader implements Serializable {
     private static final Object INCOMPATIBLE = new Object();
     private final ObjectMapper mapper;
     private final UnknownFieldListener unknownFieldListener;


### PR DESCRIPTION
This helps avoid "Task not serializable" errors when used from within Spark jobs