### PR TITLE
Added support for non-finite float and double values

### DIFF
--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonGenericRecordReader.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonGenericRecordReader.java
@@ -104,10 +104,14 @@ public class JsonGenericRecordReader {
                 result = onValidNumber(value, path, silently, Number::longValue);
                 break;
             case FLOAT:
-                result = onValidNumber(value, path, silently, Number::floatValue);
+                result = value instanceof String ? 
+                        onValidType(value, String.class, path, silently, Float::valueOf) :
+                        onValidNumber(value, path, silently, Number::floatValue);
                 break;
             case DOUBLE:
-                result = onValidNumber(value, path, silently, Number::doubleValue);
+                result = value instanceof String ?
+                        onValidType(value, String.class, path, silently, Double::valueOf) :
+                        onValidNumber(value, path, silently, Number::doubleValue);
                 break;
             case BOOLEAN:
                 result = onValidType(value, Boolean.class, path, silently, bool -> bool);


### PR DESCRIPTION
When a Java `float` or `double` value contains a non-finite value (`Infinity`, `-Infinity`, `NaN`) it is serialized in JSON as a String instead of a number (e.g. `3.1416`), as JSON numbers do not support non-finite values.

If we try to convert a JSON with such values to AVRO it will fail.

We have added support in `JsonGenericRecordReader` to support parsing `float` and `double` numbers as strings so `"NaN"`, `"Infinite"` and `"-Infinite"` are now parseable.