### PR TITLE
[converter] - Deserialize arrays as GenericData.Array instances

### DIFF
--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonGenericRecordReader.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/JsonGenericRecordReader.java
@@ -135,7 +135,11 @@ public class JsonGenericRecordReader {
     }
 
     private List<Object> readArray(Schema.Field field, Schema schema, List<Object> items, Deque<String> path) {
-        return items.stream().map(item -> read(field, schema.getElementType(), item, path, false)).collect(toList());
+        List<Object> array = new GenericData.Array<Object>(items.size(), schema);
+        for (Object item: items) {
+            array.add(read(field, schema.getElementType(), item, path, false));
+        }
+        return array;
     }
 
     private Map<String, Object> readMap(Schema.Field field, Schema schema, Map<String, Object> map, Deque<String> path) {


### PR DESCRIPTION
This is the List implementation returned by Avro's default GenericData
class, therefore this makes the JsonAvroConverter behave more like a
standard Avro datum reader.

GenericData.Array instances have the advantage that they know the
schema that elements in the array should have, as opposed to standard
ArrayLists.