### PR TITLE
feat: add date-time and decimal logical type

### DIFF
--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/CompositeJsonToAvroReader.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/CompositeJsonToAvroReader.java
@@ -4,7 +4,9 @@ import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import tech.allegro.schema.json2avro.converter.types.ArrayConverter;
+import tech.allegro.schema.json2avro.converter.types.BytesDecimalConverter;
 import tech.allegro.schema.json2avro.converter.types.EnumConverter;
+import tech.allegro.schema.json2avro.converter.types.LongTimestampMillisConverter;
 import tech.allegro.schema.json2avro.converter.types.MapConverter;
 import tech.allegro.schema.json2avro.converter.types.NullConverter;
 import tech.allegro.schema.json2avro.converter.types.PrimitiveConverter;
@@ -57,6 +59,8 @@ public class CompositeJsonToAvroReader implements JsonToAvroReader {
         this.mainRecordConverter = new RecordConverter(this, unknownFieldListener);
         this.converters = new ArrayList<>();
         this.converters.addAll(additionalConverters);
+        this.converters.add(BytesDecimalConverter.INSTANCE);
+        this.converters.add(LongTimestampMillisConverter.INSTANCE);
         this.converters.add(PrimitiveConverter.BOOLEAN);
         this.converters.add(PrimitiveConverter.STRING);
         this.converters.add(PrimitiveConverter.INT);

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/AvroTypeConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/AvroTypeConverter.java
@@ -6,11 +6,6 @@ import java.util.Deque;
 
 public interface AvroTypeConverter {
     /**
-     * This object should be returned by `convert` method when silently is true when the value type is not compatible with the avro type
-     */
-    Object INCOMPATIBLE = new Object();
-
-    /**
      * convert the json jsonValue to the avro jsonValue
      *
      * @param field the field to convert
@@ -19,7 +14,7 @@ public interface AvroTypeConverter {
      * @param path the path of the field
      * @param silently should be false to throw an error in case of incompatible java type for the avro type
      *
-     * @return the converted jsonValue
+     * @return the converted jsonValue or an Incompatible instance if silently is true and value is incompatible
      */
     Object convert(Schema.Field field, Schema schema, Object jsonValue, Deque<String> path, boolean silently);
 
@@ -35,5 +30,13 @@ public interface AvroTypeConverter {
 
     static boolean isLogicalType(Schema schema, String logicalType) {
         return schema.getLogicalType() != null && logicalType.equals(schema.getLogicalType().getName());
+    }
+
+    class Incompatible {
+        public final String expected;
+
+        public Incompatible(String expected) {
+            this.expected = expected;
+        }
     }
 }

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/AvroTypeConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/AvroTypeConverter.java
@@ -6,7 +6,7 @@ import java.util.Deque;
 
 public interface AvroTypeConverter {
     /**
-     * This object should be returned by `convert` method when silently is false when the value type is not compatible with the avro type
+     * This object should be returned by `convert` method when silently is true when the value type is not compatible with the avro type
      */
     Object INCOMPATIBLE = new Object();
 
@@ -32,4 +32,8 @@ public interface AvroTypeConverter {
      * @return true if this class should be used to convert the value
      */
     boolean canManage(Schema schema, Deque<String> path);
+
+    static boolean isLogicalType(Schema schema, String logicalType) {
+        return schema.getLogicalType() != null && logicalType.equals(schema.getLogicalType().getName());
+    }
 }

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/AvroTypeConverterWithStrictJavaTypeCheck.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/AvroTypeConverterWithStrictJavaTypeCheck.java
@@ -6,6 +6,8 @@ import tech.allegro.schema.json2avro.converter.PathsPrinter;
 
 import java.util.Deque;
 
+import static tech.allegro.schema.json2avro.converter.PathsPrinter.print;
+
 public abstract class AvroTypeConverterWithStrictJavaTypeCheck<T> implements AvroTypeConverter {
     private final Class<T> javaType;
 
@@ -20,7 +22,7 @@ public abstract class AvroTypeConverterWithStrictJavaTypeCheck<T> implements Avr
             return this.convertValue(field, schema, (T) jsonValue, path, silently);
         } else {
             if (silently) {
-                return INCOMPATIBLE;
+                return new Incompatible(this.javaType.getTypeName());
             } else {
                 throw typeException(path, javaType.getTypeName());
             }
@@ -30,11 +32,6 @@ public abstract class AvroTypeConverterWithStrictJavaTypeCheck<T> implements Avr
     public abstract Object convertValue(Schema.Field field, Schema schema, T value, Deque<String> path, boolean silently);
 
     private static AvroTypeException typeException(Deque<String> fieldPath, String expectedType) {
-        return new AvroTypeException(new StringBuilder()
-                .append("Field ")
-                .append(PathsPrinter.print(fieldPath))
-                .append(" is expected to be type: ")
-                .append(expectedType)
-                .toString());
+        return new AvroTypeException("Field " + print(fieldPath) + " is expected to be type: " + expectedType);
     }
 }

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/BytesDecimalConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/BytesDecimalConverter.java
@@ -25,7 +25,7 @@ public class BytesDecimalConverter implements AvroTypeConverter {
             return ByteBuffer.wrap(bigDecimal.unscaledValue().toByteArray());
         } catch (NumberFormatException exception) {
             if (silently) {
-                return INCOMPATIBLE;
+                return new Incompatible("string number, decimal");
             } else {
                 throw new AvroTypeException("Field " + print(path) + " is expected to be a valid number. current value is " + value + ".");
             }

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/BytesDecimalConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/BytesDecimalConverter.java
@@ -1,0 +1,47 @@
+package tech.allegro.schema.json2avro.converter.types;
+
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.Deque;
+
+import static org.apache.avro.Schema.Type.BYTES;
+import static tech.allegro.schema.json2avro.converter.PathsPrinter.print;
+
+public class BytesDecimalConverter implements AvroTypeConverter {
+    public static final AvroTypeConverter INSTANCE = new BytesDecimalConverter();
+
+    private BytesDecimalConverter() {
+
+    }
+
+    @Override
+    public Object convert(Schema.Field field, Schema schema, Object value, Deque<String> path, boolean silently) {
+        int scale = (int) schema.getObjectProp("scale");
+        try {
+            BigDecimal bigDecimal = bigDecimalWithExpectedScale(value.toString(), scale);
+            return ByteBuffer.wrap(bigDecimal.unscaledValue().toByteArray());
+        } catch (NumberFormatException exception) {
+            if (silently) {
+                return INCOMPATIBLE;
+            } else {
+                throw new AvroTypeException("Field " + print(path) + " is expected to be a valid number. current value is " + value + ".");
+            }
+        }
+    }
+
+    @Override
+    public boolean canManage(Schema schema, Deque<String> deque) {
+        return BYTES.equals(schema.getType())
+                && AvroTypeConverter.isLogicalType(schema, "decimal")
+                && schema.getObjectProp("scale") != null;
+    }
+
+    private BigDecimal bigDecimalWithExpectedScale(String decimal, int scale) {
+        BigDecimal bigDecimalInput = new BigDecimal(decimal);
+        return bigDecimalInput
+                .multiply(BigDecimal.TEN.pow(scale - bigDecimalInput.scale()));
+    }
+}

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/EnumConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/EnumConverter.java
@@ -9,6 +9,7 @@ import java.util.Deque;
 import java.util.List;
 
 import static java.util.stream.Collectors.joining;
+import static tech.allegro.schema.json2avro.converter.PathsPrinter.print;
 
 public class EnumConverter extends AvroTypeConverterWithStrictJavaTypeCheck<String> {
     public static final AvroTypeConverter INSTANCE = new EnumConverter();
@@ -32,11 +33,6 @@ public class EnumConverter extends AvroTypeConverterWithStrictJavaTypeCheck<Stri
     }
 
     private static AvroTypeException enumException(Deque<String> fieldPath, String expectedSymbols) {
-        return new AvroTypeException(new StringBuilder()
-                .append("Field ")
-                .append(PathsPrinter.print(fieldPath))
-                .append(" is expected to be of enum type and be one of ")
-                .append(expectedSymbols)
-                .toString());
+        return new AvroTypeException("Field " + print(fieldPath) + " is expected to be of enum type and be one of " + expectedSymbols);
     }
 }

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/LongTimestampMillisConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/LongTimestampMillisConverter.java
@@ -15,6 +15,7 @@ import static tech.allegro.schema.json2avro.converter.types.AvroTypeConverter.is
 
 public class LongTimestampMillisConverter implements AvroTypeConverter {
     public static final AvroTypeConverter INSTANCE = new LongTimestampMillisConverter(DateTimeFormatter.ISO_DATE_TIME);
+    public static final String VALID_JSON_FORMAT = "date time string, timestamp number";
 
     private final DateTimeFormatter dateTimeFormatter;
 
@@ -31,7 +32,7 @@ public class LongTimestampMillisConverter implements AvroTypeConverter {
                 return dateTimestamp * 1000;
             } catch (DateTimeParseException exception) {
                 if (silently) {
-                    return INCOMPATIBLE;
+                    return new Incompatible(VALID_JSON_FORMAT);
                 } else {
                     throw new AvroTypeException("Field " + print(path) + " should be a valid date time.");
                 }
@@ -41,7 +42,7 @@ public class LongTimestampMillisConverter implements AvroTypeConverter {
         }
 
         if (silently) {
-            return INCOMPATIBLE;
+            return new Incompatible(VALID_JSON_FORMAT);
         } else {
             throw new AvroTypeException("Field " + print(path) + " is expected to be type: java.lang.String or java.lang.Number.");
         }

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/LongTimestampMillisConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/LongTimestampMillisConverter.java
@@ -1,0 +1,54 @@
+package tech.allegro.schema.json2avro.converter.types;
+
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import tech.allegro.schema.json2avro.converter.PathsPrinter;
+
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.util.Deque;
+
+import static org.apache.avro.Schema.Type.LONG;
+import static tech.allegro.schema.json2avro.converter.PathsPrinter.print;
+import static tech.allegro.schema.json2avro.converter.types.AvroTypeConverter.isLogicalType;
+
+public class LongTimestampMillisConverter implements AvroTypeConverter {
+    public static final AvroTypeConverter INSTANCE = new LongTimestampMillisConverter(DateTimeFormatter.ISO_DATE_TIME);
+
+    private final DateTimeFormatter dateTimeFormatter;
+
+    public LongTimestampMillisConverter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
+    }
+
+    @Override
+    public Object convert(Schema.Field field, Schema schema, Object jsonValue, Deque<String> path, boolean silently) {
+        if (jsonValue instanceof String) {
+            String dateString = (String) jsonValue;
+            try {
+                long dateTimestamp = dateTimeFormatter.parse(dateString).getLong(ChronoField.INSTANT_SECONDS);
+                return dateTimestamp * 1000;
+            } catch (DateTimeParseException exception) {
+                if (silently) {
+                    return INCOMPATIBLE;
+                } else {
+                    throw new AvroTypeException("Field " + print(path) + " should be a valid date time.");
+                }
+            }
+        } else if (jsonValue instanceof Number) {
+            return ((Number) jsonValue).longValue();
+        }
+
+        if (silently) {
+            return INCOMPATIBLE;
+        } else {
+            throw new AvroTypeException("Field " + print(path) + " is expected to be type: java.lang.String or java.lang.Number.");
+        }
+    }
+
+    @Override
+    public boolean canManage(Schema schema, Deque<String> deque) {
+        return LONG.equals(schema.getType()) && isLogicalType(schema, "timestamp-millis");
+    }
+}

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/NullConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/NullConverter.java
@@ -13,7 +13,7 @@ public class NullConverter implements AvroTypeConverter {
 
     @Override
     public Object convert(Schema.Field field, Schema schema, Object jsonValue, Deque<String> path, boolean silently) {
-        return jsonValue == null ? null : INCOMPATIBLE;
+        return jsonValue == null ? null : new Incompatible("NULL");
     }
 
     @Override

--- a/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/JsonAvroConverterSpec.groovy
+++ b/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/JsonAvroConverterSpec.groovy
@@ -8,6 +8,7 @@ import spock.lang.Specification
 import com.fasterxml.jackson.databind.ObjectMapper
 import tech.allegro.schema.json2avro.converter.types.AvroTypeConverter
 
+import java.nio.ByteBuffer
 import java.time.LocalDateTime
 import java.time.ZoneOffset;
 
@@ -72,7 +73,7 @@ class JsonAvroConverterSpec extends Specification {
         toMap(json) == toMap(converter.convertToJson(avro, schema))
     }
 
-    def 'should convert bytes generic record'() {
+    def "should convert bytes generic record"() {
         given:
         def schema = '''
             {
@@ -894,6 +895,339 @@ class JsonAvroConverterSpec extends Specification {
 
         then:
         !toMap(converter.convertToJson(avro, schema)).payload.foo
+    }
+
+    def "should convert iso date time to timestamp-millis"() {
+        given:
+        def converter = new JsonAvroConverter()
+        def schema = '''
+            {
+              "type" : "record",
+              "name" : "testSchema",
+              "fields" : [
+                  {
+                    "name" : "datetime",
+                    "type" : {
+                      "type" : "long",
+                      "logicalType" : "timestamp-millis"
+                    }
+                  }
+              ]
+            }
+        '''
+
+        def json = '''
+        {
+            "datetime": "2022-02-05T16:20:29Z"
+        }
+        '''
+
+        when:
+        GenericData.Record record = converter.convertToGenericDataRecord(json.bytes, new Schema.Parser().parse(schema))
+
+        then:
+        LocalDateTime.of(2022, 02, 05, 16, 20, 29).toEpochSecond(ZoneOffset.UTC) * 1000 == record.get("datetime")
+    }
+
+    def "should convert long time to timestamp-millis"() {
+        given:
+        def converter = new JsonAvroConverter()
+        def schema = '''
+            {
+              "type" : "record",
+              "name" : "testSchema",
+              "fields" : [
+                  {
+                    "name" : "datetime",
+                    "type" : {
+                      "type" : "long",
+                      "logicalType" : "timestamp-millis"
+                    }
+                  }
+              ]
+            }
+        '''
+
+        def json = '''
+        {
+            "datetime": 1644078029000
+        }
+        '''
+
+        when:
+        GenericData.Record record = converter.convertToGenericDataRecord(json.bytes, new Schema.Parser().parse(schema))
+
+        then:
+        1644078029000 == record.get("datetime")
+    }
+
+    def "should fail if date time is malformed"() {
+        given:
+        def converter = new JsonAvroConverter()
+        def schema = '''
+            {
+              "type" : "record",
+              "name" : "testSchema",
+              "fields" : [
+                  {
+                    "name" : "datetime",
+                    "type" : {
+                      "type" : "long",
+                      "logicalType" : "timestamp-millis"
+                    }
+                  }
+              ]
+            }
+        '''
+
+        def json = '''
+        {
+            "datetime": "test"
+        }
+        '''
+
+        when:
+        converter.convertToGenericDataRecord(json.bytes, new Schema.Parser().parse(schema))
+
+        then:
+        def e = thrown AvroConversionException
+        e.message == "Failed to convert JSON to Avro: Field datetime should be a valid date time."
+    }
+
+    def "should fail if date is not a String nor a Long"() {
+        given:
+        def converter = new JsonAvroConverter()
+        def schema = '''
+            {
+              "type" : "record",
+              "name" : "testSchema",
+              "fields" : [
+                  {
+                    "name" : "datetime",
+                    "type" : {
+                      "type" : "long",
+                      "logicalType" : "timestamp-millis"
+                    }
+                  }
+              ]
+            }
+        '''
+
+        def json = '''
+        {
+            "datetime": {}
+        }
+        '''
+
+        when:
+        converter.convertToGenericDataRecord(json.bytes, new Schema.Parser().parse(schema))
+
+        then:
+        def e = thrown AvroConversionException
+        e.message == "Failed to convert JSON to Avro: Field datetime is expected to be type: java.lang.String or java.lang.Number."
+    }
+
+    def "should allow a timestamp-millis to be nullable"() {
+        given:
+        def converter = new JsonAvroConverter()
+        def schema = '''
+            {
+              "type" : "record",
+              "name" : "testSchema",
+              "fields" : [
+                  {
+                    "name" : "datetime",
+                    "type" : [{
+                      "type" : "long",
+                      "logicalType" : "timestamp-millis"
+                    }, "null"]
+                  }
+              ]
+            }
+        '''
+
+        def json = '''
+        {
+            "datetime": null
+        }
+        '''
+
+        when:
+        GenericData.Record record = converter.convertToGenericDataRecord(json.bytes, new Schema.Parser().parse(schema))
+
+        then:
+        null == record.get("datetime")
+    }
+
+    def "should throw error when timestamp-millis malformed on union type"() {
+        given:
+        def converter = new JsonAvroConverter()
+        def schema = '''
+            {
+              "type" : "record",
+              "name" : "testSchema",
+              "fields" : [
+                  {
+                    "name" : "datetime",
+                    "type" : [{
+                      "type" : "long",
+                      "logicalType" : "timestamp-millis"
+                    }, "null"]
+                  }
+              ]
+            }
+        '''
+
+        def json = '''
+        {
+            "datetime": "test"
+        }
+        '''
+
+        when:
+        converter.convertToGenericDataRecord(json.bytes, new Schema.Parser().parse(schema))
+
+        then:
+        def e = thrown AvroConversionException
+        e.message == "Failed to convert JSON to Avro: Could not evaluate union, field datetime is expected to be one of these: LONG, NULL. If this is a complex type, check if offending field: datetime adheres to schema."
+    }
+
+    def "should convert json numeric to avro decimal"() {
+        given:
+        def converter = new JsonAvroConverter()
+        def schema = '''
+            {
+              "type" : "record",
+              "name" : "testSchema",
+              "fields" : [
+                  {
+                    "name" : "byteDecimal",
+                    "type" : {
+                      "type" : "bytes",
+                      "logicalType" : "decimal",
+                      "precision": 15, 
+                      "scale": 5
+                    }
+                  }
+              ]
+            }
+        '''
+
+        def json = '''
+        {
+            "byteDecimal": 123.456
+        }
+        '''
+
+        when:
+        GenericData.Record record = converter.convertToGenericDataRecord(json.bytes, new Schema.Parser().parse(schema))
+
+        then:
+        new BigDecimal("123.45600") == new BigDecimal(new BigInteger(((ByteBuffer) record.get("byteDecimal")).array()), 5)
+    }
+
+    def "should convert json string to avro decimal"() {
+        given:
+        def converter = new JsonAvroConverter()
+        def schema = '''
+            {
+              "type" : "record",
+              "name" : "testSchema",
+              "fields" : [
+                  {
+                    "name" : "byteDecimal",
+                    "type" : {
+                      "type" : "bytes",
+                      "logicalType" : "decimal",
+                      "precision": 15, 
+                      "scale": 5
+                    }
+                  }
+              ]
+            }
+        '''
+
+        def json = '''
+        {
+            "byteDecimal": "123.456"
+        }
+        '''
+
+        when:
+        GenericData.Record record = converter.convertToGenericDataRecord(json.bytes, new Schema.Parser().parse(schema))
+
+        then:
+        new BigDecimal("123.45600") == new BigDecimal(new BigInteger(((ByteBuffer) record.get("byteDecimal")).array()), 5)
+    }
+
+    def "should throw error when decimal json string is not a number"() {
+        given:
+        def converter = new JsonAvroConverter()
+        def schema = '''
+            {
+              "type" : "record",
+              "name" : "testSchema",
+              "fields" : [
+                  {
+                    "name" : "byteDecimal",
+                    "type" : {
+                      "type" : "bytes",
+                      "logicalType" : "decimal",
+                      "precision": 15, 
+                      "scale": 5
+                    }
+                  }
+              ]
+            }
+        '''
+
+        def json = '''
+        {
+            "byteDecimal": "test"
+        }
+        '''
+
+        when:
+        converter.convertToGenericDataRecord(json.bytes, new Schema.Parser().parse(schema))
+
+        then:
+        def e = thrown AvroConversionException
+        e.message == "Failed to convert JSON to Avro: Field byteDecimal is expected to be a valid number. current value is test."
+    }
+
+    def "should throw error when decimal is malformed on a union type"() {
+        given:
+        def converter = new JsonAvroConverter()
+        def schema = '''
+            {
+              "type" : "record",
+              "name" : "testSchema",
+              "fields" : [
+                  {
+                    "name" : "byteDecimal",
+                    "type" : [{
+                      "type" : "bytes",
+                      "logicalType" : "decimal",
+                      "precision": 15, 
+                      "scale": 5
+                    }, "null"]
+                  }
+              ]
+            }
+        '''
+
+        def json = '''
+        {
+            "byteDecimal": "test"
+        }
+        '''
+
+        when:
+        converter.convertToGenericDataRecord(json.bytes, new Schema.Parser().parse(schema))
+
+        then:
+        def e = thrown AvroConversionException
+        e.message == "Failed to convert JSON to Avro: Could not evaluate union, field byteDecimal is expected to be one of these: BYTES, NULL. If this is a complex type, check if offending field: byteDecimal adheres to schema."
     }
 
     def "should convert specific record"() {

--- a/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/JsonAvroConverterSpec.groovy
+++ b/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/JsonAvroConverterSpec.groovy
@@ -1089,7 +1089,7 @@ class JsonAvroConverterSpec extends Specification {
 
         then:
         def e = thrown AvroConversionException
-        e.message == "Failed to convert JSON to Avro: Could not evaluate union, field datetime is expected to be one of these: LONG, NULL. If this is a complex type, check if offending field: datetime adheres to schema."
+        e.message == "Failed to convert JSON to Avro: Could not evaluate union, field datetime is expected to be one of these: date time string, timestamp number, NULL. If this is a complex type, check if offending field: datetime adheres to schema."
     }
 
     def "should convert json numeric to avro decimal"() {
@@ -1227,7 +1227,7 @@ class JsonAvroConverterSpec extends Specification {
 
         then:
         def e = thrown AvroConversionException
-        e.message == "Failed to convert JSON to Avro: Could not evaluate union, field byteDecimal is expected to be one of these: BYTES, NULL. If this is a complex type, check if offending field: byteDecimal adheres to schema."
+        e.message == "Failed to convert JSON to Avro: Could not evaluate union, field byteDecimal is expected to be one of these: string number, decimal, NULL. If this is a complex type, check if offending field: byteDecimal adheres to schema."
     }
 
     def "should convert specific record"() {


### PR DESCRIPTION
## Why

Allow to automatically convert date-time and decimal logical type. 

For exemple now the following JSON can be converted:

```
{
   "stringDate": "2022-02-05T16:20:29Z",
   "timestamp": 1644078029000,
   "stringBigDecimal": "123.456",
   "decimalBigDecimal": 123.456,
}
```

## How

Adding two new `AvroTypeConverter` for datetime, and bigdecimals.

Removing usage of `INCOMPATIBLE` constant, to have better error management for logical types.

## Advantage

There are no need to add custom code to convert json common format to avro
