### PR TITLE
Ability to return logical types instead of raw types as a result of conversions

### DIFF
--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/CompositeJsonToAvroReader.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/CompositeJsonToAvroReader.java
@@ -59,7 +59,7 @@ public class CompositeJsonToAvroReader implements JsonToAvroReader {
      * @param unknownFieldListener the listener to customize unknown field error management
      */
     public CompositeJsonToAvroReader(List<AvroTypeConverter> additionalConverters, UnknownFieldListener unknownFieldListener) {
-        this.mainRecordConverter = new RecordConverter(this, unknownFieldListener);
+        this.mainRecordConverter = createMainConverter(unknownFieldListener);
         this.converters = new ArrayList<>();
         this.converters.addAll(additionalConverters);
         this.converters.add(BytesDecimalConverter.INSTANCE);
@@ -81,6 +81,10 @@ public class CompositeJsonToAvroReader implements JsonToAvroReader {
         this.converters.add(new ArrayConverter(this));
         this.converters.add(new MapConverter(this));
         this.converters.add(new UnionConverter(this));
+    }
+
+    protected AvroTypeConverter createMainConverter(UnknownFieldListener unknownFieldListener) {
+        return new RecordConverter(this, unknownFieldListener);
     }
 
     @Override

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/AbstractDateTimeConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/AbstractDateTimeConverter.java
@@ -16,7 +16,7 @@ public abstract class AbstractDateTimeConverter implements AvroTypeConverter {
         if (jsonValue instanceof String) {
             String dateTimeString = (String) jsonValue;
             try {
-                return parseDateTime(dateTimeString);
+                return convertDateTimeString(dateTimeString);
             } catch (DateTimeParseException exception) {
                 if (silently) {
                     return new Incompatible(getValidJsonFormat());
@@ -25,7 +25,7 @@ public abstract class AbstractDateTimeConverter implements AvroTypeConverter {
                 }
             }
         } else if (jsonValue instanceof Number) {
-            return toTargetNumberFormat((Number) jsonValue);
+            return convertNumber((Number) jsonValue);
         }
 
         if (silently) {
@@ -40,9 +40,9 @@ public abstract class AbstractDateTimeConverter implements AvroTypeConverter {
         return getUnderlyingSchemaType().equals(schema.getType()) && AvroTypeConverter.isLogicalType(schema, getLogicalType().getName());
     }
 
-    protected abstract Object parseDateTime(String dateTimeString);
+    protected abstract Object convertDateTimeString(String dateTimeString);
 
-    protected abstract Object toTargetNumberFormat(Number numberValue);
+    protected abstract Object convertNumber(Number numberValue);
 
     protected abstract Schema.Type getUnderlyingSchemaType();
 

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/AbstractIntDateTimeConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/AbstractIntDateTimeConverter.java
@@ -5,7 +5,7 @@ import org.apache.avro.Schema;
 public abstract class AbstractIntDateTimeConverter extends AbstractDateTimeConverter {
 
     @Override
-    protected Object toTargetNumberFormat(Number numberValue) {
+    protected Object convertNumber(Number numberValue) {
         return numberValue.intValue();
     }
 

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/AbstractLongDateTimeConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/AbstractLongDateTimeConverter.java
@@ -5,7 +5,7 @@ import org.apache.avro.Schema;
 public abstract class AbstractLongDateTimeConverter extends AbstractDateTimeConverter {
 
     @Override
-    protected Object toTargetNumberFormat(Number numberValue) {
+    protected Object convertNumber(Number numberValue) {
         return numberValue.longValue();
     }
 

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/IntDateConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/IntDateConverter.java
@@ -16,8 +16,12 @@ public class IntDateConverter extends AbstractIntDateTimeConverter {
     }
 
     @Override
-    protected Object parseDateTime(String dateTimeString) {
-        return LocalDate.from(dateTimeFormatter.parse(dateTimeString)).toEpochDay();
+    protected Object convertDateTimeString(String dateTimeString) {
+        return parseLocalDate(dateTimeString).toEpochDay();
+    }
+
+    protected LocalDate parseLocalDate(String dateTimeString) {
+        return LocalDate.from(dateTimeFormatter.parse(dateTimeString));
     }
 
     @Override

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/IntTimeMillisConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/IntTimeMillisConverter.java
@@ -17,9 +17,13 @@ public class IntTimeMillisConverter extends AbstractIntDateTimeConverter {
     }
 
     @Override
-    protected Object parseDateTime(String dateTimeString) {
-        long nanoOfDay = LocalTime.from(dateTimeFormatter.parse(dateTimeString)).toNanoOfDay();
+    protected Object convertDateTimeString(String dateTimeString) {
+        long nanoOfDay = parseLocalTime(dateTimeString).toNanoOfDay();
         return TimeUnit.NANOSECONDS.toMillis(nanoOfDay);
+    }
+
+    protected LocalTime parseLocalTime(String dateTimeString) {
+        return LocalTime.from(dateTimeFormatter.parse(dateTimeString));
     }
 
     @Override

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/LongTimeMicrosConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/LongTimeMicrosConverter.java
@@ -17,9 +17,13 @@ public class LongTimeMicrosConverter extends AbstractLongDateTimeConverter {
     }
 
     @Override
-    protected Object parseDateTime(String dateTimeString) {
-        long nanoOfDay = LocalTime.from(dateTimeFormatter.parse(dateTimeString)).toNanoOfDay();
+    protected Object convertDateTimeString(String dateTimeString) {
+        long nanoOfDay = parseLocalTime(dateTimeString).toNanoOfDay();
         return TimeUnit.NANOSECONDS.toMicros(nanoOfDay);
+    }
+
+    protected LocalTime parseLocalTime(String dateTimeString) {
+        return LocalTime.from(dateTimeFormatter.parse(dateTimeString));
     }
 
     @Override

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/LongTimestampMicrosConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/LongTimestampMicrosConverter.java
@@ -16,8 +16,8 @@ public class LongTimestampMicrosConverter extends AbstractLongDateTimeConverter 
     }
 
     @Override
-    protected Object parseDateTime(String dateTimeString) {
-        Instant instant = Instant.from(dateTimeFormatter.parse(dateTimeString));
+    protected Object convertDateTimeString(String dateTimeString) {
+        Instant instant = parseInstant(dateTimeString);
         // based on org.apache.avro.data.TimestampMicrosConversion
         long seconds = instant.getEpochSecond();
         int nanos = instant.getNano();
@@ -32,6 +32,10 @@ public class LongTimestampMicrosConverter extends AbstractLongDateTimeConverter 
 
             return Math.addExact(micros, nanos / 1_000);
         }
+    }
+
+    protected Instant parseInstant(String dateTimeString) {
+        return Instant.from(dateTimeFormatter.parse(dateTimeString));
     }
 
     @Override

--- a/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/LongTimestampMillisConverter.java
+++ b/converter/src/main/java/tech/allegro/schema/json2avro/converter/types/LongTimestampMillisConverter.java
@@ -16,8 +16,12 @@ public class LongTimestampMillisConverter extends AbstractLongDateTimeConverter 
     }
 
     @Override
-    protected Object parseDateTime(String dateTimeString) {
-        return Instant.from(dateTimeFormatter.parse(dateTimeString)).toEpochMilli();
+    protected Object convertDateTimeString(String dateTimeString) {
+        return parseInstant(dateTimeString).toEpochMilli();
+    }
+
+    protected Instant parseInstant(String dateTimeString) {
+        return Instant.from(dateTimeFormatter.parse(dateTimeString));
     }
 
     @Override

--- a/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/LogicalTypeConverterSpec.groovy
+++ b/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/LogicalTypeConverterSpec.groovy
@@ -1,0 +1,105 @@
+package tech.allegro.schema.json2avro.converter
+
+import org.apache.avro.Schema
+import org.apache.avro.data.RecordBuilderBase
+import org.apache.avro.generic.GenericData
+import spock.lang.Specification
+import tech.allegro.schema.json2avro.converter.types.AvroTypeConverter
+import tech.allegro.schema.json2avro.converter.types.IntDateConverter
+import tech.allegro.schema.json2avro.converter.types.RecordConverter
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+class LogicalTypeConverterSpec extends Specification {
+
+    def logicalTypeIntDateConverter = new IntDateConverter(DateTimeFormatter.ISO_DATE) {
+        @Override
+        protected Object convertDateTimeString(String dateTimeString) {
+            return parseLocalDate(dateTimeString)
+        }
+        @Override
+        protected Object convertNumber(Number numberValue) {
+            return LocalDate.ofEpochDay(super.convertNumber(numberValue) as int)
+        }
+    }
+
+    def converter = new JsonAvroConverter(new CompositeJsonToAvroReader(Collections.singletonList(logicalTypeIntDateConverter)) {
+        @Override
+        protected AvroTypeConverter createMainConverter(UnknownFieldListener unknownFieldListener) {
+            return new RecordConverter(this, unknownFieldListener) {
+                @Override
+                protected RecordBuilderBase<GenericData.Record> createRecordBuilder(Schema schema) {
+                    new LogicalTypeGenericRecordBuilder(schema)
+                }
+
+                @Override
+                protected void setField(RecordBuilderBase<GenericData.Record> builder, Schema.Field subField, Object fieldValue) {
+                    (builder as LogicalTypeGenericRecordBuilder).set(subField, fieldValue)
+                }
+            }
+        }
+    })
+
+    def schema = new Schema.Parser().parse('''
+            {
+              "type" : "record",
+              "name" : "testSchema",
+              "fields" : [
+                  {
+                    "name" : "date",
+                    "type" : {
+                      "type" : "int",
+                      "logicalType" : "date"
+                    },
+                    "default": 123
+                  }
+              ]
+            }
+        ''')
+
+    def "should convert date string to LocalDate"() {
+        given:
+        def json = '''
+        {
+            "date": "1970-01-02"
+        }
+        '''
+
+        when:
+        GenericData.Record record = converter.convertToGenericDataRecord(json.bytes, schema)
+
+        then:
+        LocalDate.ofEpochDay(1) == record.get("date")
+    }
+
+    def "should convert number to LocalDate"() {
+        given:
+        def json = '''
+        {
+            "date": 1.0
+        }
+        '''
+
+        when:
+        GenericData.Record record = converter.convertToGenericDataRecord(json.bytes, schema)
+
+        then:
+        LocalDate.ofEpochDay(1) == record.get("date")
+    }
+
+    def "should return default value as a LocalDate"() {
+        given:
+        def json = '''
+        {}
+        '''
+
+        when:
+        GenericData.Record record = converter.convertToGenericDataRecord(json.bytes, schema)
+
+        then:
+        LocalDate.ofEpochDay(123) == record.get("date")
+    }
+
+
+}

--- a/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/LogicalTypeGenericRecordBuilder.groovy
+++ b/converter/src/test/groovy/tech/allegro/schema/json2avro/converter/LogicalTypeGenericRecordBuilder.groovy
@@ -1,0 +1,59 @@
+package tech.allegro.schema.json2avro.converter
+
+import org.apache.avro.AvroRuntimeException
+import org.apache.avro.Schema
+import org.apache.avro.data.RecordBuilderBase
+import org.apache.avro.data.TimeConversions
+import org.apache.avro.generic.GenericData
+
+// copy-paste from GenericRecordBuilder with changed GenericData
+class LogicalTypeGenericRecordBuilder extends RecordBuilderBase<GenericData.Record> {
+
+    static LOGICAL_TYPE_GENERIC_DATA = new GenericData()
+
+    static {
+        LOGICAL_TYPE_GENERIC_DATA.addLogicalTypeConversion(new TimeConversions.DateConversion())
+    }
+
+    private GenericData.Record record;
+
+    LogicalTypeGenericRecordBuilder(Schema schema) {
+        super(schema, LOGICAL_TYPE_GENERIC_DATA)
+        record = new GenericData.Record(schema)
+    }
+
+    LogicalTypeGenericRecordBuilder set(Schema.Field field, Object value) {
+        record.put(field.pos(), value);
+        fieldSetFlags()[field.pos()] = true;
+        return this;
+    }
+
+    @Override
+    GenericData.Record build() {
+        GenericData.Record record;
+        try {
+            record = new GenericData.Record(schema());
+        } catch (Exception e) {
+            throw new AvroRuntimeException(e)
+        }
+
+        for (Schema.Field field : fields()) {
+            Object value;
+            try {
+                value = getWithDefault(field)
+            } catch (IOException e) {
+                throw new AvroRuntimeException(e);
+            }
+            if (value != null) {
+                record.put(field.pos(), value)
+            }
+        }
+
+        return record
+    }
+
+    private Object getWithDefault(Schema.Field field) throws IOException {
+        return fieldSetFlags()[field.pos()] ? record.get(field.pos()) : defaultValue(field);
+    }
+
+}


### PR DESCRIPTION
Hi @szczygiel-m , sorry for disturbing one more time :) I've tried recently released version and almost all works like a charm. The only thing that is missed in conversion mechanism is ability to convert provided json values to more java friendly types instead of current Avro raw once. So now is conversion pipeline looks like:
```
1) "1970-01-01" -> 2) LocalDate.ofEpochDay(1) -> 3) 1 (int)
```
And I want to stop on step 2. It is very similar to what happen when you use avro-maven-plugin and generate java classes based on schema using logicalTypes.

I know that it is rather unusual usage of json2avro library so the only thing that I want to change is to give ability to users to override some methods to change to such behavior on their side. Provided test demonstrates the idea. WDYAT?